### PR TITLE
bug: add aes support for darwin/arm64

### DIFF
--- a/internal/cpuarm64/cpuarm64_darwin_arm64.go
+++ b/internal/cpuarm64/cpuarm64_darwin_arm64.go
@@ -1,0 +1,22 @@
+// Copyright 2020 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build arm64 && darwin && !ios
+
+package cpuarm64
+
+// There are no hw.optional sysctl values for the below features on Mac OS 11.0
+// to detect their supported state dynamically. Assume the CPU features that
+// Apple Silicon M1 supports to be available as a minimal set of features
+// to all Go programs running on darwin/arm64.
+
+// HasAES returns whether the CPU supports AES.
+func HasAES() bool {
+	return true
+}
+
+// HasPMULL returns whether the CPU supports PMULL.
+func HasPMULL() bool {
+	return true
+}

--- a/internal/cpuarm64/cpuarm64_otherwise.go
+++ b/internal/cpuarm64/cpuarm64_otherwise.go
@@ -1,4 +1,4 @@
-//go:build !android || !arm64
+//go:build arm64 && !android && !darwin
 
 package cpuarm64
 

--- a/internal/cpuarm64/doc.go
+++ b/internal/cpuarm64/doc.go
@@ -18,5 +18,9 @@
 // choose AES in crypto/tls when the CPU supports it.
 //
 // This package is only a replacement for arm64. We use x/sys/cpu for
-// all arm64 systems but Android where we call getauxval(3).
+// all arm64 systems but Android where we call getauxval(3), *except* for
+// the concrete case of darwin/arm64, since the x/sys/cpu support for
+// darmin/arm64 is not implemented:
+// https://github.com/golang/go/issues/43046
+
 package cpuarm64


### PR DESCRIPTION
`x/sys/cpu` lacks support for `darwin/arm64`, so here I am porting over the hardcoded implementation from `internal/cpu`.

For reference:

* https://github.com/golang/go/issues/43046
* https://github.com/golang/go/issues/42747

- Fixes: https://github.com/ooni/probe/issues/2122