### PR TITLE
fix: ensure the conn we export implements NetConn

### DIFF
--- a/tls/stdlibwrapper.go
+++ b/tls/stdlibwrapper.go
@@ -86,9 +86,17 @@ func NewClientConnStdlib(conn net.Conn, config *stdlibtls.Config) (*ConnStdlib, 
 // We use this type instead of directly using *Conn to simplify unit
 // testing of the ConnStdlib.ConnectionState method.
 type connStdlibUnderlyingConn interface {
+	// We need to have the same methods of a net.Conn
 	net.Conn
+
+	// We need to be able to handshake
 	HandshakeContext(ctx context.Context) error
+
+	// We need to get the TLS connection state
 	ConnectionState() ConnectionState
+
+	// We need to get the underlying net.Conn
+	NetConn() net.Conn
 }
 
 // ConnStdlib is the Conn-like type returned by NewClientConnStdlib. This type
@@ -106,7 +114,9 @@ type connStdlibOOHTTPTLSLikeConn interface {
 
 	HandshakeContext(ctx context.Context) error
 
-	ConnectionState() stdlibtls.ConnectionState
+	ConnectionState() stdlibtls.ConnectionState // We need to cast to stdlib
+
+	NetConn() net.Conn
 }
 
 var _ connStdlibOOHTTPTLSLikeConn = &ConnStdlib{} // ensure we implement this interface

--- a/tls/stdlibwrapper_test.go
+++ b/tls/stdlibwrapper_test.go
@@ -67,6 +67,9 @@ type connStdlibUnderlyingConnMockable struct {
 
 	// MockHandshakeContext allows to mock the HandshakeContext method.
 	MockHandshakeContext func(ctx context.Context) error
+
+	// MockNetConn allows to mock the NetConn method
+	MockNetConn func() net.Conn
 }
 
 // ConnectionState calls MockConnectionState.
@@ -77,6 +80,11 @@ func (c *connStdlibUnderlyingConnMockable) ConnectionState() ConnectionState {
 // HandshakeContext calls MockHandshakeContext.
 func (c *connStdlibUnderlyingConnMockable) HandshakeContext(ctx context.Context) error {
 	return c.MockHandshakeContext(ctx)
+}
+
+// NetConn calls MockNetConn
+func (c *connStdlibUnderlyingConnMockable) NetConn() net.Conn {
+	return c.MockNetConn()
 }
 
 func TestConnStdlib_ConnectionState(t *testing.T) {


### PR DESCRIPTION
I am not sure there's any issue in _building_ against the latest
stable release of oocrypto (and I shall soon see), but in any case
it feels more correct to include `NetConn()` into the model.

Part of https://github.com/ooni/probe/issues/2211